### PR TITLE
Set multicast socket time to live

### DIFF
--- a/modules/common/src/main/java/edu/tigers/sumatra/network/MulticastUDPTransmitter.java
+++ b/modules/common/src/main/java/edu/tigers/sumatra/network/MulticastUDPTransmitter.java
@@ -88,6 +88,7 @@ public class MulticastUDPTransmitter implements AutoCloseable
 				@SuppressWarnings("squid:S2095") // closing resources: can not close resource here
 				var socket = new MulticastSocket();
 				socket.setNetworkInterface(nif);
+				socket.setTimeToLive(32);
 				sockets.add(new TargetSocket(socket));
 			}
 		} catch (IOException e)


### PR DESCRIPTION
Currently, multicats socket TTL is not set and in fact it appears to be set to 1 as the default behavior.
In practice match in Japan, we use tracker packets from autoref but some team could not receive them due to TTL setting.

Similar case: https://github.com/RoboCup-SSL/ssl-game-controller/pull/147

So, this pull-request set the TTL of multicast socket to 32.
This patch is tested in the practice match in Japan. 
